### PR TITLE
Style Back/Next quiz navigation buttons

### DIFF
--- a/src/views/quiz/question.rs
+++ b/src/views/quiz/question.rs
@@ -74,7 +74,7 @@ pub fn question(data: QuestionData, locale: &str) -> Markup {
                 }
                 div style="display: flex; gap: 1rem; margin-top: 1rem; align-items: center;" {
                     @if data.question_idx > 0 {
-                        button type="button" class="nav-btn"
+                        button type="button" class="nav-btn nav-btn-back"
                                hx-get=(format!("/question/{}?question_idx={}", data.session_id, data.question_idx - 1))
                                hx-target="main"
                                hx-swap="innerHTML" {
@@ -151,7 +151,7 @@ pub fn answer(data: AnswerData, locale: &str) -> Markup {
 
             @if data.from_context.as_deref() == Some("report") {
                 div style="display: flex; gap: 1rem; margin-top: 1rem; align-items: center;" {
-                    button class="nav-btn"
+                    button class="nav-btn nav-btn-back"
                            hx-get=(names::results_url(data.session_id))
                            hx-push-url="true"
                            hx-target="main"
@@ -159,12 +159,11 @@ pub fn answer(data: AnswerData, locale: &str) -> Markup {
                         (t!("quiz.back_to_results", locale = locale))
                     }
                     @if let Some(current) = data.current_idx {
-                        button class="nav-btn"
+                        button class="nav-btn nav-btn-next"
                                hx-get=(format!("/question/{}?question_idx={}", data.session_id, current))
                                hx-push-url="true"
                                hx-target="main"
-                               hx-disabled-elt="this"
-                               style="background-color: #007bff; color: white;" {
+                               hx-disabled-elt="this" {
                             (t!("quiz.return_to_current", locale = locale))
                         }
                     }
@@ -172,7 +171,7 @@ pub fn answer(data: AnswerData, locale: &str) -> Markup {
             } @else {
                 div style="display: flex; gap: 1rem; margin-top: 1rem; align-items: center;" {
                     @if data.question_idx > 0 {
-                        button type="button" class="nav-btn"
+                        button type="button" class="nav-btn nav-btn-back"
                                hx-get=(format!("/question/{}?question_idx={}", data.session_id, data.question_idx - 1))
                                hx-target="main"
                                hx-swap="innerHTML" {
@@ -180,12 +179,12 @@ pub fn answer(data: AnswerData, locale: &str) -> Markup {
                         }
                     }
                     @if is_final {
-                        button class="nav-btn"
+                        button class="nav-btn nav-btn-next"
                                hx-get=(names::results_url(data.session_id))
                                hx-push-url="true"
                                hx-target="main" hx-disabled-elt="this" { (t!("quiz.see_results", locale = locale)) }
                     } @else {
-                        button class="nav-btn"
+                        button class="nav-btn nav-btn-next"
                                hx-get=(names::quiz_page_url(data.quiz_id))
                                hx-target="main" hx-disabled-elt="this" { (t!("quiz.next", locale = locale)) }
                     }

--- a/static/index.css
+++ b/static/index.css
@@ -116,6 +116,42 @@ body {
   height: auto !important;
   padding: 0.5rem 1rem !important;
   margin-bottom: 0 !important;
+  border: none !important;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.nav-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.nav-btn:active {
+  transform: translateY(0);
+}
+
+.nav-btn-back {
+  background: linear-gradient(135deg, #6c757d, #495057) !important;
+  color: #fff !important;
+}
+
+.nav-btn-back:hover {
+  filter: brightness(1.08);
+}
+
+.nav-btn-next {
+  background: linear-gradient(135deg, #0d6efd, #0b5ed7) !important;
+  color: #fff !important;
+}
+
+.nav-btn-next:hover {
+  filter: brightness(1.08);
+}
+
+.nav-btn:disabled {
+  filter: grayscale(0.35);
+  opacity: 0.7;
+  box-shadow: none;
+  transform: none;
 }
 
 /* 言語切替プルダウン */


### PR DESCRIPTION
### Motivation
- Provide clearer visual distinction between "back" and "next/forward" actions on quiz screens so navigation is more discoverable and consistent.
- Avoid inline styles for action buttons and centralize styling in the main stylesheet for easier maintenance.
- Skills used: none.

### Description
- Added semantic classes `nav-btn-back` and `nav-btn-next` to quiz navigation buttons in `src/views/quiz/question.rs` so back/next actions can be styled independently.
- Removed the inline `style` color on the "return to current question" button and migrated its appearance to the new `nav-btn-next` class.
- Introduced styling in `static/index.css` to give `.nav-btn-back` a gray gradient and `.nav-btn-next` a blue gradient, plus hover/active transitions and a consistent disabled state.
- Kept existing `.nav-btn` sizing while adding subtle motion and shadow affordances for better UX.

### Testing
- Ran `cargo test`, which completed successfully (unit/db tests passed). 
- Launched the app locally and exercised the quiz flows via the running server (`cargo run`) to verify the views render correctly and navigation buttons appear with the new styles. 
- Automated UI checks using Playwright scripts to create a sample quiz, start a session, answer questions, and capture screenshots; screenshots were generated to validate the updated button visuals (`browser:/tmp/codex_browser_invocations/aab70a784be53774/artifacts/artifacts/nav-buttons.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953165f960832680dbb3ee1b442ded)