### PR TITLE
Add 3-way theme mode toggle (light/dark/system) with modern lightweight styling

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,6 +5,10 @@ layout.lang_toggle_en: "English"
 layout.lang_toggle_ja: "日本語"
 layout.lang_toggle_zh_cn: "简体中文"
 layout.lang_toggle_zh_tw: "繁體中文"
+layout.theme_aria_label: "Theme"
+layout.theme_light: "Light"
+layout.theme_dark: "Dark"
+layout.theme_system: "System"
 
 # Homepage - Get Started
 homepage.welcome: "Welcome to Quizinart!"

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -5,6 +5,10 @@ layout.lang_toggle_en: "English"
 layout.lang_toggle_ja: "日本語"
 layout.lang_toggle_zh_cn: "简体中文"
 layout.lang_toggle_zh_tw: "繁體中文"
+layout.theme_aria_label: "テーマ"
+layout.theme_light: "ライト"
+layout.theme_dark: "ダーク"
+layout.theme_system: "システム"
 
 # Homepage - Get Started
 homepage.welcome: "Quizinart へようこそ！"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -5,6 +5,10 @@ layout.lang_toggle_en: "English"
 layout.lang_toggle_ja: "日本語"
 layout.lang_toggle_zh_cn: "简体中文"
 layout.lang_toggle_zh_tw: "繁體中文"
+layout.theme_aria_label: "主题"
+layout.theme_light: "浅色"
+layout.theme_dark: "深色"
+layout.theme_system: "跟随系统"
 
 # Homepage - Get Started
 homepage.welcome: "欢迎使用 Quizinart！"

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -5,6 +5,10 @@ layout.lang_toggle_en: "English"
 layout.lang_toggle_ja: "日本語"
 layout.lang_toggle_zh_cn: "简体中文"
 layout.lang_toggle_zh_tw: "繁體中文"
+layout.theme_aria_label: "主題"
+layout.theme_light: "淺色"
+layout.theme_dark: "深色"
+layout.theme_system: "跟隨系統"
 
 # Homepage - Get Started
 homepage.welcome: "歡迎使用 Quizinart！"

--- a/static/index.css
+++ b/static/index.css
@@ -5,6 +5,59 @@ body {
   font-family: 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
+main {
+  animation: fade-in 0.18s ease-out;
+}
+
+header nav {
+  backdrop-filter: saturate(130%) blur(6px);
+}
+
+header nav ul {
+  gap: 0.5rem;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+:root {
+  --option-correct-bg: #d4edda;
+  --option-correct-border: #28a745;
+  --option-correct-text: #155724;
+
+  --option-incorrect-bg: #f8d7da;
+  --option-incorrect-border: #dc3545;
+  --option-incorrect-text: #721c24;
+
+  --option-neutral-bg: #f8f9fa;
+  --option-neutral-border: #dee2e6;
+  --option-neutral-text: #495057;
+  --option-neutral-subtext: #6c757d;
+}
+
+[data-theme="dark"] {
+  --option-correct-bg: #193529;
+  --option-correct-border: #4ccb75;
+  --option-correct-text: #b7f5c7;
+
+  --option-incorrect-bg: #3b1e24;
+  --option-incorrect-border: #ff6b81;
+  --option-incorrect-text: #ffc0ca;
+
+  --option-neutral-bg: #252b33;
+  --option-neutral-border: #3a4552;
+  --option-neutral-text: #d7dce3;
+  --option-neutral-subtext: #a8b0bb;
+}
+
 .quiz-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -25,20 +78,20 @@ body {
 
 /* 正解の選択肢（緑） */
 .option-correct {
-  background-color: #d4edda;
-  border: 2px solid #28a745;
+  background-color: var(--option-correct-bg);
+  border: 2px solid var(--option-correct-border);
   border-radius: 8px;
   padding: 1rem;
   margin-bottom: 1rem;
 }
 
 .option-correct label {
-  color: #155724;
+  color: var(--option-correct-text);
   font-weight: 500;
 }
 
 .option-correct .explanation {
-  color: #155724;
+  color: var(--option-correct-text);
   margin-left: 2rem;
   margin-top: 0.5rem;
   font-size: 0.9rem;
@@ -47,20 +100,20 @@ body {
 
 /* 不正解の選択肢（選択したもの）（赤） */
 .option-incorrect {
-  background-color: #f8d7da;
-  border: 2px solid #dc3545;
+  background-color: var(--option-incorrect-bg);
+  border: 2px solid var(--option-incorrect-border);
   border-radius: 8px;
   padding: 1rem;
   margin-bottom: 1rem;
 }
 
 .option-incorrect label {
-  color: #721c24;
+  color: var(--option-incorrect-text);
   font-weight: 500;
 }
 
 .option-incorrect .explanation {
-  color: #721c24;
+  color: var(--option-incorrect-text);
   margin-left: 2rem;
   margin-top: 0.5rem;
   font-size: 0.9rem;
@@ -69,19 +122,19 @@ body {
 
 /* その他の選択肢（選択されなかった不正解）（グレー） */
 .option-neutral {
-  background-color: #f8f9fa;
-  border: 1px solid #dee2e6;
+  background-color: var(--option-neutral-bg);
+  border: 1px solid var(--option-neutral-border);
   border-radius: 8px;
   padding: 1rem;
   margin-bottom: 1rem;
 }
 
 .option-neutral label {
-  color: #495057;
+  color: var(--option-neutral-text);
 }
 
 .option-neutral .explanation {
-  color: #6c757d;
+  color: var(--option-neutral-subtext);
   margin-left: 2rem;
   margin-top: 0.5rem;
   font-size: 0.9rem;
@@ -122,6 +175,21 @@ body {
 .lang-select {
   width: auto;
   margin: 0;
-  padding: 0.25rem 0.5rem;
+  padding: 0.3rem 0.65rem;
   font-size: 0.85rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--pico-color) 15%, transparent);
+  background: color-mix(in srgb, var(--pico-background-color) 84%, var(--pico-muted-color));
+  box-shadow: none;
+}
+
+.theme-select {
+  width: auto;
+  margin: 0;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.85rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--pico-primary) 22%, transparent);
+  background: color-mix(in srgb, var(--pico-primary-background) 24%, var(--pico-background-color));
+  box-shadow: none;
 }


### PR DESCRIPTION
### Motivation
- Provide users a lightweight, modern theme control with three modes: `light`, `dark`, and `system` so the UI can follow OS preference or be explicitly set. 
- Improve readability for quiz results by making correct/incorrect/neutral colors theme-aware. 
- Polish the top navigation for a cleaner, modern appearance while keeping the UI lightweight.

### Description
- Added client-side theme logic in `src/views/layout.rs` that persists the chosen mode to `localStorage`, resolves `system` to the OS `prefers-color-scheme`, and sets `data-theme` / `data-theme-mode` on the document element. 
- Inserted a header theme selector (`select.theme-select`) with three options and i18n `THEMES` labels, rendered alongside the existing language selector in `src/views/layout.rs`. 
- Updated `static/index.css` to introduce CSS variables for option/result colors, provide dark-mode overrides under `[data-theme="dark"]`, and add UI polish (fade-in, backdrop blur, pill-shaped selects). 
- Added i18n keys for the theme selector to `locales/en.yml`, `locales/ja.yml`, `locales/zh-CN.yml`, and `locales/zh-TW.yml`.

### Testing
- Ran `cargo test`, which completed successfully (unit and DB tests passed). 
- Launched the app with `cargo run` against a local file DB and confirmed the server started and served the UI. 
- Automated browser validation using Playwright to open the homepage, switch `.theme-select` to `dark`, and capture a screenshot showing the theme toggle behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954a6213d88326bd7aa3e03f9c0a34)