### PR TITLE
Fix i32 overflow in quiz session payload parsing

### DIFF
--- a/src/handlers/quiz/mod.rs
+++ b/src/handlers/quiz/mod.rs
@@ -22,10 +22,10 @@ fn deserialize_string_or_i32<'de, D: serde::Deserializer<'de>>(d: D) -> Result<i
             f.write_str("number or numeric string")
         }
         fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<i32, E> {
-            Ok(v as i32)
+            i32::try_from(v).map_err(E::custom)
         }
         fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<i32, E> {
-            Ok(v as i32)
+            i32::try_from(v).map_err(E::custom)
         }
         fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<i32, E> {
             v.parse().map_err(E::custom)
@@ -93,4 +93,37 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/session/{id}/delete", delete(session::delete_session))
         .route("/session/{id}/rename", patch(session::rename_session))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_session_body_accepts_numeric_string() {
+        let body: StartSessionBody = serde_json::from_str(
+            r#"{"name":"alice","question_count":"10","selection_mode":"random"}"#,
+        )
+        .expect("should parse numeric string");
+
+        assert_eq!(body.question_count, 10);
+    }
+
+    #[test]
+    fn start_session_body_rejects_out_of_range_i64() {
+        let result = serde_json::from_str::<StartSessionBody>(
+            r#"{"name":"alice","question_count":2147483648,"selection_mode":"random"}"#,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn start_session_body_rejects_out_of_range_u64() {
+        let result = serde_json::from_str::<StartSessionBody>(
+            r#"{"name":"alice","question_count":9223372036854775808,"selection_mode":"random"}"#,
+        );
+
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent silent integer truncation when deserializing `question_count` from JSON, which could wrap large `i64`/`u64` values into incorrect `i32` values and produce unexpected behavior before downstream clamping.
- Make deserialization fail loudly for out-of-range values so callers can handle invalid input safely.

### Description
- Replaced lossy casts in the `serde` visitor with checked conversions by using `i32::try_from` in `deserialize_string_or_i32` to convert `i64`/`u64` to `i32` and map failures to serde errors.
- Added unit tests in `src/handlers/quiz/mod.rs` that validate `StartSessionBody` parsing: numeric string parsing, rejection of out-of-range signed integers, and rejection of out-of-range unsigned integers.
- Kept existing behavior for string inputs by still parsing numeric strings with `v.parse()`.

### Testing
- Added focused unit tests under `src/handlers/quiz/mod.rs` (three cases) to cover the change.
- Ran `cargo fmt --check`, which passed.
- Attempted `cargo test --locked`, but test execution could not complete due to crates.io index access being blocked (HTTP 403 during dependency download), so tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964699037c832692f2979eefb327a1)